### PR TITLE
Create update_games.yml

### DIFF
--- a/.github/workflows/update_games.yml
+++ b/.github/workflows/update_games.yml
@@ -1,0 +1,58 @@
+on:
+  workflow_dispatch:
+  push:
+    paths: ["data/games.rds"]
+
+name: Update Games and Schedules
+permissions: read-all
+
+jobs:
+  update_games:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.NFLVERSE_GH_TOKEN }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+          extra-repositories: 'https://nflverse.r-universe.dev'
+
+      - name: Install dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: nflverse/nflverse-data
+
+      - name: Release games data
+        run: |
+          cli::rule("Start games data update process")
+          # Load currently released data
+          released <- nflreadr::rds_from_url(paste0(
+            "https://github.com/nflverse/nflverse-data/",
+            "releases/download/schedules/games.rds"
+          ))
+
+          # Load data in nfldata repo
+          repo_data <- readRDS("data/games.rds")
+
+          # The workflow should only trigger if the data changed but it doesn't hurt
+          # to make sure we only update the data if the comparison shows that something
+          # really has changed
+          if (!identical(released, repo_data)) {
+            cli::cli_alert_info("Going to release updated games data.")
+            out <- dplyr::rows_upsert(released, repo_data, by = "game_id")
+            nflversedata::nflverse_save(
+              data_frame = out,
+              file_name = "games",
+              nflverse_type = "games and schedules",
+              release_tag = "schedules",
+              file_types = c("rds", "csv", "parquet", "qs", "csv.gz"),
+            )
+          } else {
+            cli::cli_alert_success("Nothing changed. Games data is up to date.")
+          }
+          cli::rule("Process complete")
+        shell: Rscript {0}


### PR DESCRIPTION
This adds a GHA workflow that triggers on push to `data/games.rds`. It fetches current games data from the nflverse-data release tag `schedules`, compares to games data in this repo and updates the release data, if necessary. 